### PR TITLE
chore(minecraft/pikachu): disable mixin debug

### DIFF
--- a/minecraft/minecraft/minecraft-forge-pikachu.yaml
+++ b/minecraft/minecraft/minecraft-forge-pikachu.yaml
@@ -68,7 +68,7 @@ spec:
       eula: "TRUE"
       onlineMode: false
       version: "1.12.2"
-      jvmOpts: "-Xmns3G -Xmnx7G -Xgcpolicy:balanced -Xdisableexplicitgc -Dfml.readTimeout=300 -Dmixin.debug=true"
+      jvmOpts: "-Xmns3G -Xmnx7G -Xgcpolicy:balanced -Xdisableexplicitgc -Dfml.readTimeout=300"
       forgeVersion: "14.23.5.2860"
       gameMode: "0"
       forcegameMode: false


### PR DESCRIPTION
Currently, mixin debug is enabled in prod, it makes unnecessary noise.
I propose leaving it enabled in dev for ongoing debugging purposes.