### PR TITLE
chore(ci/renovate): capture docker images in latest itzg chart values

### DIFF
--- a/.github/renovate-go.json5
+++ b/.github/renovate-go.json5
@@ -117,6 +117,7 @@
       "fileMatch": ["./.+\\.yaml$"],
       "matchStrings": [
         "image: (?<depName>.*?)\n *imageTag: (?<currentValue>.*)\n",
+        "repository: (?<depName>.*?)\n *tag: (?<currentValue>.*)\n",
       ],
       "datasourceTemplate": "docker",
     },


### PR DESCRIPTION
Add an extra regex matching pattern for the Renovate `docker` datasource.
This will capture latest pattern used to define images in the latest chart versions from `itzg`.

https://github.com/PixelmonToGo/gitops-k8s/blob/83de4a9d50be02e08ce7fa3b45055ed3bb65fa1c/minecraft/minecraft/minecraft-proxy.yaml#L45-L47