### PR TITLE
chore(ci/renovate): add custom versioning regex for itzg/bungeecord

### DIFF
--- a/.github/renovate-go.json5
+++ b/.github/renovate-go.json5
@@ -102,6 +102,10 @@
       "prCreation": "immediate",
       "stabilityDays": 0,
       "versioning": "regex:^(?<compatibility>.*)-v(?<major>\\d+)(\\.(?<minor>\\d+))(\\.(?<patch>\\d+))$",
+    },
+    {
+      "matchPackageNames": ["itzg/bungeecord"],
+      "versioning": "regex:^(?<compatibility>.*)-(?<major>\\d+)(\\.(?<minor>\\d+))(\\.(?<patch>\\d+))$",
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
Fixes this:
```
DEBUG: Dependency itzg/bungeecord has unsupported value java17-2022.1.0 (repository=PixelmonToGo/gitops-k8s)
```