### PR TITLE
chore(minecraft-dev/proxy): remove redundant parallelism patch

### DIFF
--- a/minecraft-dev/minecraft/minecraft-proxy.yaml
+++ b/minecraft-dev/minecraft/minecraft-proxy.yaml
@@ -65,7 +65,6 @@ spec:
       jvmOpts: >-
         --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
         -Dlog4j2.formatMsgNoLookups=true
-        -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
       extraPorts:
         - name: vote
           containerPort: 8192
@@ -89,7 +88,7 @@ spec:
           - target:
               version: v1
               kind: Deployment
-              name: minecraft-proxy-dev 
+              name: minecraft-proxy-dev
             patch:
               - op: add
                 path: /spec/template/spec/containers/0/env/0


### PR DESCRIPTION
This patch introduced in #992 is no longer required; the bug (https://github.com/DV8FromTheWorld/JDA/issues/1858) was remediated in Java 17.0.2, included in the current image `itzg/bungeecord:2022.4.1` (#999).
